### PR TITLE
feat: Update Cloud Build region to global

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,14 +5,14 @@ steps:
     args:
       - 'build'
       - '-t'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
       - '.'
 
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
 
   # Deploy container image to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -22,9 +22,9 @@ steps:
       - 'deploy'
       - 'go-cloudrun-example'
       - '--image'
-      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
       - '--region'
-      - 'asia-northeast1'
+      - 'global'
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'


### PR DESCRIPTION
Updated the Cloud Build configuration to use 'global' region instead of 'asia-northeast1' for Artifact Registry and Cloud Run deployment.