### PR TITLE
feat: Change Cloud Build region to asia-northeast1

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,14 +5,14 @@ steps:
     args:
       - 'build'
       - '-t'
-      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
       - '.'
 
   # Push the container image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
 
   # Deploy container image to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -22,9 +22,9 @@ steps:
       - 'deploy'
       - 'go-cloudrun-example'
       - '--image'
-      - 'global-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
+      - 'asia-northeast1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/go-cloudrun-example:$COMMIT_SHA'
       - '--region'
-      - 'global'
+      - 'asia-northeast1'
       - '--platform'
       - 'managed'
       - '--allow-unauthenticated'


### PR DESCRIPTION
Updated the Cloud Build configuration to use 'asia-northeast1' region for Artifact Registry and Cloud Run deployment, replacing the previous 'global' setting.